### PR TITLE
Change edit to explore

### DIFF
--- a/plugin/vinegar.vim
+++ b/plugin/vinegar.vim
@@ -29,7 +29,7 @@ if !exists("g:netrw_special_syntax")
 endif
 let s:netrw_up = ''
 
-nnoremap <silent> <Plug>VinegarUp :call <SID>opendir('edit')<CR>
+nnoremap <silent> <Plug>VinegarUp :call <SID>opendir('Explore')<CR>
 if empty(maparg('-', 'n'))
   nmap - <Plug>VinegarUp
 endif


### PR DESCRIPTION
does not keep orphan/stray netrw buffers in bufferlist
regardless of the setting of 'hidden'.
For more details see issues 13, 66, and 74 in the repository of tpope